### PR TITLE
Add Header component and integrate into Feed page

### DIFF
--- a/frontend/src/assets/components/Header.jsx
+++ b/frontend/src/assets/components/Header.jsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+const Header = () => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <header className="relative p-4 bg-[var(--bg)] shadow-md text-[var(--acc)] font-[bebas]">
+      <div className="flex justify-between items-center">
+        <h1 className="text-4xl">
+            <span className="text-[var(--acc)]">BUFF</span>
+            <span className="text-[var(--hl)]">BUDS</span>
+        </h1>
+
+        {/* Desktop Nav */}
+        <nav className="hidden md:flex items-center space-x-6 text-lg">
+            <Link className="hover:text-[var(--hl)] transition" to="/">Feed</Link>
+            <Link className="hover:text-[var(--hl)] transition" to="/workout">Workout</Link>
+            <Link className="hover:text-[var(--hl)] transition" to="/analytics">Analytics</Link>
+            <Link className="hover:text-[var(--hl)] transition" to="/profile/**user**">Profile</Link>
+        <button className="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded-md transition">
+        Logout
+        </button>
+        </nav>
+
+
+        {/* Mobile Menu Button */}
+        <button
+          className="md:hidden text-2xl"
+          onClick={() => setMenuOpen(!menuOpen)}
+        >
+          ☰
+        </button>
+      </div>
+
+      {/* Mobile Dropdown */}
+      {menuOpen && (
+        <nav className="absolute top-full left-0 w-full md:hidden flex flex-col space-y-6 text-lg bg-gray-700 p-6 z-50">
+            <Link to="/" onClick={() => setMenuOpen(false)}>Feed</Link>
+            <Link to="/workout" onClick={() => setMenuOpen(false)}>Workout</Link>
+            <Link to="/analytics" onClick={() => setMenuOpen(false)}>Analytics</Link>
+            <Link to="/profile/**user**" onClick={() => setMenuOpen(false)}>Profile</Link>
+            <button
+            className="bg-red-500 text-white px-3 py-2 rounded w-fit"
+            onClick={() => setMenuOpen(false)}
+            >
+            Logout
+            </button>
+        </nav>
+        )}
+    </header>
+  );
+};
+
+export default Header;

--- a/frontend/src/assets/pages/Feed.jsx
+++ b/frontend/src/assets/pages/Feed.jsx
@@ -1,7 +1,10 @@
+import Header from "../components/Header"
 const Feed = () => {
     return (
+        
         <div>
-            <h1>Feed Page</h1>
+            <Header />
+            <h1 className="flex items-center justify-center">Feed Page</h1>
         </div>
     )
 }


### PR DESCRIPTION
This pull request introduces a new responsive header component and improves authentication handling in the sign-in flow. The header provides navigation links and logout functionality for both desktop and mobile views, and the sign-in page now updates authentication state and username upon successful login. Additionally, the `Feed` page now displays the header, and a dependency update is included.

**UI Enhancements:**

* Added a new `Header` component in `Header.jsx` with navigation links and logout button, supporting both desktop and mobile dropdown menus.
* Updated the `Feed` page to include the new `Header` component for consistent navigation.

**Authentication Improvements:**

* Modified the `SignIn` component to accept `setIsAuthed` and `setUsername` props, enabling authentication state and username updates after login. [[1]](diffhunk://#diff-a1fee8548cea764610d1ed663a631e61429626078ba835b43f5d0e851b6b9243L5-R5) [[2]](diffhunk://#diff-a1fee8548cea764610d1ed663a631e61429626078ba835b43f5d0e851b6b9243R21-R26)
* Updated the `/signin` route in `App.jsx` to pass the new props to `SignIn`.

**Dependency Update:**

* Upgraded the `vite` dependency from version `7.1.6` to `7.1.7` in `package.json`.